### PR TITLE
Update nginx and tileserver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ letsencrypt/
 
 # logs for nginx and letsencrypt
 logs/
+
+# DSStore
+.DS_Store

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,5 +1,8 @@
-FROM nginx:1.24.0-alpine3.17-slim
+FROM nginx:1.26.1-alpine3.19-slim
 
+RUN apk update 
+RUN apk add openssl 
+RUN apk upgrade --no-cache
 RUN apk add certbot certbot-nginx
 
 COPY ./conf.d/ /etc/nginx/conf.d/

--- a/tileserver/Dockerfile
+++ b/tileserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM maptiler/tileserver-gl:v4.4.10
+FROM maptiler/tileserver-gl:v4.12.0
 
 COPY ./config.json /data
 COPY ./basemap.mbtiles /data


### PR DESCRIPTION
Update to nginx 1.26.1
Update to tileserver 4.12.0

closes #3

## Additional context

The base image for nginx alpine is affected by a CVE. Upgrading the packages moves them to versions that are not affected, alleviating the vulnerability.

## Bonus Update

While we're in there, might as well update the tileserver