### PR TITLE
Block external connections for tileserver

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -25,6 +25,6 @@ services:
   tileserver:
     build: ./tileserver
     ports:
-      - 8080:8080
+      - 127.0.0.1:8080:8080
     volumes:
       - ./tileserver/data:/data


### PR DESCRIPTION
Update compose file to only allow local machines to connect to tileserver service

closes NYCPlanning/ae-private#82